### PR TITLE
Blank lat lng on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@
 
 ### About
 
-A react-leaflet control to display the coordinates under the cursor.  Supports decimal degrees and DMS.
+A react-leaflet control to display the coordinates under the cursor. Supports decimal degrees and DMS.
 
 ### Installation
-
 
 ```
 npm install --save react-leaflet-coordinates
@@ -21,45 +20,41 @@ yarn install
 Simply import the `CoordinateControl` and place as a child of the `Map` component.
 
 ```javascript
-import React, { Component } from 'react'
-import { Map, TileLayer } from 'react-leaflet'
+import React, { Component } from "react";
+import { Map, TileLayer } from "react-leaflet";
 
-import { CoordinatesControl } from 'react-leaflet-coordinates'
+import { CoordinatesControl } from "react-leaflet-coordinates";
 
 export default class App extends Component {
-
-render () {
-  return (
+  render() {
+    return (
       <div className="map">
-        <Map
-          center={[44.635, 22.653]}
-          zoom={12}
-          zoomControl={false} >
-
+        <Map center={[44.635, 22.653]} zoom={12} zoomControl={false}>
           <TileLayer
             attribution="Google Maps"
-            url="https://mt0.google.com/vt/lyrs=s&x={x}&y={y}&z={z}"/>
+            url="https://mt0.google.com/vt/lyrs=s&x={x}&y={y}&z={z}"
+          />
 
           <CoordinatesControl />
         </Map>
       </div>
-    )
+    );
   }
 }
 ```
 
 ### Props
 
-Name | Default | Description
---- | --- | ---
-position | `bottomleft` | Position of the control.  Valid values are `topleft`, `topright`, `bottomleft`, or `bottomright`
-style | `null` | A react css style prop for the button.
-coordinates | `decimal` | Coordinate system to use.  Valid values are `decimal` (decimal lat/lng) or `degrees` (degrees, minutes, seconds)
-
+| Name          | Default                                  | Description                                                                                                     |
+| ------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| position      | `bottomleft`                             | Position of the control. Valid values are `topleft`, `topright`, `bottomleft`, or `bottomright`                 |
+| style         | `null`                                   | A react css style prop for the button.                                                                          |
+| coordinates   | `decimal`                                | Coordinate system to use. Valid values are `decimal` (decimal lat/lng) or `degrees` (degrees, minutes, seconds) |
+| latLngDefault | `{lat: '0.00000000', lng: '0.00000000'}` | Sets an initial lat lng                                                                                         |
 
 ### Development
 
-This was created with `create-react-library`.  To develop locally run the library in the root directory.
+This was created with `create-react-library`. To develop locally run the library in the root directory.
 
 ```
 yarn install

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -23,7 +23,6 @@ export default class App extends Component {
 						<CoordinatesControl 
 							coordinates="decimal"
 							position="bottomleft"
-							latLngDefault={{lat: '10.00000000', lng: '20.00000000'}}
 						/>
 
 					</Map>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -23,6 +23,7 @@ export default class App extends Component {
 						<CoordinatesControl 
 							coordinates="decimal"
 							position="bottomleft"
+							latLngDefault={{lat: '10.00000000', lng: '20.00000000'}}
 						/>
 
 					</Map>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takor/react-leaflet-coordinates",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "React Leaflet control to show the coordinates under the cursor",
   "author": "ChrisLowe-Takor",
   "license": "MIT",

--- a/src/leaflet-coordinates.js
+++ b/src/leaflet-coordinates.js
@@ -29,7 +29,7 @@ L.Control.CoordinateControl = L.Control.extend({
 	_coordinates: 'decimal',
 	initialize: function(element) {
 		this.options.position = element.position;
-		
+		this.latLngDefault = element.latLngDefault || {lat: '0.00000000', lng: '0.00000000'};
 		this._coordinates = element.coordinates || 'decimal';
 
 		if (element.style === undefined) {
@@ -70,7 +70,7 @@ L.Control.CoordinateControl = L.Control.extend({
         if (this._coordinates === 'degrees') {
             var wrappedLng = this.wrapLongitudeCoordinates(e.latlng.lng)
             var lat = e ? this.convertDecimalLatToDegrees(e.latlng.lat) : '';
-            var lng = e ? this.convertDecimalLngToDegrees(wrappedLng) : '';
+            var lng = e ? this.convertDecimalLngToDegrees(wrappedLng) : ''; 
             this._coordinateButton.innerHTML = 
             "<div id='coordinate-control-degrees-container'>" +
                 "<strong id='coordinate-control-degrees-title-lat'>Latitude: </strong>" +
@@ -95,8 +95,8 @@ L.Control.CoordinateControl = L.Control.extend({
 					"</div>" + 
 				"</div>";
         } else {
-            var lat = e ? e.latlng.lat.toLocaleString('en-US', {minimumFractionDigits: 8, useGrouping:false}):'';
-            var lng = e ? this.wrapLongitudeCoordinates(e.latlng.lng).toLocaleString('en-US', {minimumFractionDigits: 8, useGrouping:false}):'';
+            var lat = e ? e.latlng.lat.toLocaleString('en-US', {minimumFractionDigits: 8, useGrouping:false}): this.latLngDefault.lat;
+            var lng = e ? this.wrapLongitudeCoordinates(e.latlng.lng).toLocaleString('en-US', {minimumFractionDigits: 8, useGrouping:false}): this.latLngDefault.lng;
             this._coordinateButton.innerHTML = 
             "<div id='coordinate-control-decimal-container'>" +
                 "<strong id='coordinate-control-decimal-title-lat'>Latitude: </strong>" +
@@ -184,5 +184,6 @@ export default withLeaflet(CoordinatesControl);
 CoordinatesControl.propTypes = {
 	style: PropTypes.element,
 	coordinates: PropTypes.oneOf(['decimal', 'degrees', 'mgrs']),
-	position: PropTypes.oneOf(['topright', 'topleft', 'bottomright', 'bottomleft'])
+	position: PropTypes.oneOf(['topright', 'topleft', 'bottomright', 'bottomleft']),
+	latLngDefault: PropTypes.array
 }


### PR DESCRIPTION
Bumps version number to 1.0.8 

Pull fixes issue of lat lng position been empty until the user interacts with the leaflet map. 

Adds prop `latLngDefault` to pass in a value otherwise populates as a default 0.00000000 , 0.00000000

Updates the readme to reflect changes
